### PR TITLE
Use new Node LTS version `16.15.0`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js LTS (Gallium)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 16.15.0
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to NPM registry

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,8 @@
 name: cd
 
 on:
+  release:
+    types: [ created ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js LTS (Gallium)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 16.15.0
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**'
+    branches-ignore:
+      - 'main'
   workflow_dispatch:
   workflow_call:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Custom top-level framework of Express.js, especially on [TypeScript](https://git
 
 ## Installation
 
-> Node.js 16.14.2 (LTS) or higher is required.
+> Node.js 16.15.0 (LTS) or higher is required.
 
 Installing by using the following commands
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=16.14.2"
+    "node": ">=16.15.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "springpress",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0",
   "description": "Express.js top-level framework",
   "author": "Krid Heprakhone <riflowth@gmail.com>",
   "license": "MIT",
@@ -29,7 +29,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=16.15.0"
+    "node": "16.15.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",


### PR DESCRIPTION
Changes
- GitHub workflow runs on node 16.15.0
- Springpress requires 16.15.0