### PR TITLE
Improve middleware extendability on implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export abstract class Middleware {
    * Returns a function that have access to the request object,
    * the response object, and the next middleware function.
    */
-  abstract getHandler(): Promise<RouteHandler>;
+  abstract getHandler(routeMetadata: RouteMetadata): Promise<RouteHandler>;
   getRegisterCondition(): MiddlewareCondition;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,10 +22,8 @@ export abstract class Middleware {
    * @param routeMetadata - A route metadata
    */
   abstract getHandler(routeMetadata: RouteMetadata): Promise<RouteHandler>;
-  getRegisterCondition(): MiddlewareCondition;
+  getRegisterCondition(routeMethod: Methods, routeMetadata: RouteMetadata): boolean;
 }
-
-export type MiddlewareCondition = (routeMethod: Methods, routeMetadata: RouteMetadata) => boolean;
 
 export class ControllerRegistry {
   constructor(app: Express);

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ export abstract class Middleware {
   /**
    * Returns a function that have access to the request object,
    * the response object, and the next middleware function.
+   * @param routeMetadata - A route metadata
    */
   abstract getHandler(routeMetadata: RouteMetadata): Promise<RouteHandler>;
   getRegisterCondition(): MiddlewareCondition;

--- a/lib/controllers/ControllerRegistry.js
+++ b/lib/controllers/ControllerRegistry.js
@@ -31,7 +31,7 @@ class ControllerRegistry {
           .getRegisterCondition()(routeMethod, routeMetadata);
 
         if (canRegisterMiddleware) {
-          return middleware;
+          return middleware.getHandler(routeMetadata);
         }
       };
 

--- a/lib/controllers/ControllerRegistry.js
+++ b/lib/controllers/ControllerRegistry.js
@@ -28,7 +28,7 @@ class ControllerRegistry {
 
       const registerMiddleware = (middleware) => {
         const canRegisterMiddleware = middleware
-          .getRegisterCondition()(routeMethod, routeMetadata);
+          .getRegisterCondition(routeMethod, routeMetadata);
 
         if (canRegisterMiddleware) {
           return middleware.getHandler(routeMetadata);

--- a/lib/controllers/Middleware.js
+++ b/lib/controllers/Middleware.js
@@ -8,7 +8,7 @@ class Middleware {
     }
   }
 
-  async getHandler() {
+  async getHandler(routeMetadata) {
     throw new Error("Method 'getHandler()' must be implemented.");
   }
 

--- a/test/mock/MockMiddleware.ts
+++ b/test/mock/MockMiddleware.ts
@@ -1,4 +1,4 @@
-import { Middleware, MiddlewareCondition, RouteHandler } from '../..';
+import { Methods, Middleware, RouteHandler, RouteMetadata } from '../..';
 
 export class MockMiddleware extends Middleware {
 
@@ -18,10 +18,8 @@ export class MockConditionalMiddleware extends Middleware {
     };
   }
 
-  public getRegisterCondition(): MiddlewareCondition {
-    return (routeMethod, routeMetadata) => {
-      return routeMetadata.path === '/test2';
-    };
+  public getRegisterCondition(routeMethod: Methods, routeMetadata: RouteMetadata): boolean {
+    return routeMetadata.path === '/test2';
   }
 
 }


### PR DESCRIPTION
`Middleware#getHandler` should send some route information to `#getHandler` in case it may be used for doing something.