### PR TITLE
Add route metadata and controller registry utility methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-import { Express, NextFunction } from 'express';
+import { Express } from 'express';
 
 export abstract class Controller {
   /**
@@ -23,11 +23,11 @@ export interface Middleware {
    */
   getHandler(routeMetadata: RouteMetadata): RouteHandler;
   /**
-   * Returns a boolean represent to the middleware register condition
-   * @param routeMethod - A route method for conditioning
-   * @param routeMetadata - A route metadata for conditioning
-   * @returns True if a route matches the middleware register condition, otherwise returns false
-   */
+ * Returns a boolean represent to the middleware register condition
+ * @param routeMethod - A route method for conditioning
+ * @param routeMetadata - A route metadata for conditioning
+ * @returns True if a route matches the middleware register condition, otherwise returns false
+ */
   getRegisterCondition(routeMethod: Methods, routeMetadata: RouteMetadata): boolean;
 }
 
@@ -107,6 +107,12 @@ export type Route = {
   handler: RouteHandler,
   metadata: RouteMetadata,
 };
+
+export type Request = Express.Request;
+
+export type Response = Express.Request;
+
+export type NextFunction = Express.NextFunction;
 
 export abstract class Springpress {
   constructor(port: number);

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,14 @@ export type Response = Express.Request;
 
 export type NextFunction = Express.NextFunction;
 
+export class RouteUtil {
+  /**
+   * Add data into the route metadata
+   * @param data - A key-value pairs of data to merge into the route metadata
+   */
+  static addRouteMetadata(data: Record<string, any>): MethodDecorator;
+}
+
 export abstract class Springpress {
   constructor(port: number);
   abstract onStartup(): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,10 @@ export class ControllerRegistry {
    * @param middlewares - A single middleware or a group of middlewares
    */
   register(controller: Controller, ...middlewares: Middleware[]): void;
+  /**
+   * @returns A count of registered controller
+   */
+  size(): number;
 }
 
 /**

--- a/lib/controllers/ControllerRegistry.js
+++ b/lib/controllers/ControllerRegistry.js
@@ -6,14 +6,14 @@ const HttpException = require('../exceptions/HttpException');
 class ControllerRegistry {
   
   #app;
-  #controllerByPath = new Map();
+  #controllers = [];
 
   constructor(app) {
     this.#app = app;
   }
 
   register(controller, ...middlewares) {
-    if (this.#controllerByPath.has(controller.getPath())) {
+    if (this.#controllers.includes(controller.getPath())) {
       throw new Error('Register duplicated controller');
     }
 
@@ -45,6 +45,11 @@ class ControllerRegistry {
 
     this.#app.use(controller.getPath(), router);
     this.#app.use(this.#errorFallbackMiddleware());
+    this.#controllers.push(controller.getPath());
+  }
+
+  size() {
+    return this.#controllers.length;
   }
 
   #interceptError(routeHandler) {

--- a/lib/decorators/RouteDecorator.js
+++ b/lib/decorators/RouteDecorator.js
@@ -1,13 +1,9 @@
 'use strict';
 
+const RouteUtil = require("../utils/RouteUtil");
+
 const RouteMapping = (path, method) => {
-  return (target, propertyKey, descriptor) => {
-    Reflect.defineMetadata(propertyKey, {
-      ...Reflect.getMetadata(propertyKey, target),
-      path,
-      method,
-    }, target);
-  };
+  return RouteUtil.addRouteMetadata({ path, method });
 };
 
 module.exports = RouteMapping;

--- a/lib/springpress.js
+++ b/lib/springpress.js
@@ -1,9 +1,10 @@
 'use strict';
-require('reflect-metadata');
 
 /**
  * Module dependencies.
  */
+require('reflect-metadata');
+
 const Controller = require('./controllers/Controller');
 const ControllerRegistry = require('./controllers/ControllerRegistry');
 const Methods = require('./controllers/Methods');
@@ -18,6 +19,8 @@ const ForbiddenException = require('./exceptions/ForbiddenException');
 const NotFoundException = require('./exceptions/NotFoundException');
 const UnauthorizedException = require('./exceptions/UnauthorizedException');
 
+const RouteUtil = require('./utils/RouteUtil');
+
 const Springpress = require('./server/Server');
 
 /**
@@ -26,6 +29,7 @@ const Springpress = require('./server/Server');
 exports.Controller = Controller;
 exports.ControllerRegistry = ControllerRegistry;
 exports.Methods = Methods;
+exports.RouteUtil = RouteUtil;
 exports.Springpress = Springpress;
 
 /**

--- a/lib/utils/RouteUtil.js
+++ b/lib/utils/RouteUtil.js
@@ -1,0 +1,16 @@
+'use strict';
+
+class RouteUtil {
+
+  static addRouteMetadata(data) {
+    return (target, propertyKey, descriptor) => {
+      Reflect.defineMetadata(propertyKey, {
+        ...Reflect.getMetadata(propertyKey, target),
+        ...data,
+      }, target);
+    };
+  }
+
+}
+
+module.exports = RouteUtil;

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -21,6 +21,14 @@ describe('Test the ControllerRegistry class implementation', () => {
     expect(findRouter(expressApp).length).toBe(2);
   });
 
+  it('should throw an error when register a duplicated controller', () => {    
+    const registerDuplicated = () => {
+      controllerRegistry.register(new MockIndexController());
+      controllerRegistry.register(new MockIndexController());
+    };
+    expect(registerDuplicated).toThrow(Error);
+  });
+
   it('should registered the mock controller and the middleware correctly', () => {
     let router, routes;
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -45,6 +45,12 @@ describe('Test the ControllerRegistry class implementation', () => {
     expect(routes.find((layer: any) => layer.route.path === '/test2').route.stack.length).toBe(2);
   });
 
+  it('should return a registered controller count correctly', () => {
+    controllerRegistry.register(new MockIndexController());
+    controllerRegistry.register(new MockTestController(), new MockMiddleware());
+    expect(controllerRegistry.size()).toBe(2);
+  });
+
 });
 
 const findRouter = (expressApp: Express) => {


### PR DESCRIPTION
## Changes
- [x] Add route metadata utility to work with route metadata
  - #9 
- [x] Wrap own `Request`, `Response`, and `NextFunction` from Express types
  - #10 
- Add `ControllerRegistry#size` to get registered controller count